### PR TITLE
Fix syntax errors in codex_demo.py

### DIFF
--- a/codex_demo.py
+++ b/codex_demo.py
@@ -6,26 +6,26 @@ conn = sqlite3.connect("regions.db")
 cursor = conn.cursor()
 
 # Register user
-def register_user(email, password:
-    if not email or not password
+def register_user(email, password):
+    if not email or not password:
         return "Email or password missing"
 
-    if "@" not in email
+    if "@" not in email:
         return "Invalid email address"
 
     hashed = hashlib.sha256(password.encode()).hexdigest()
-    sql = f"INSERT INTO users (email, password) VALUES ('{email}', '{hashed}'"
-    cursor.execute(sql)
+    sql = "INSERT INTO users (email, password) VALUES (?, ?)"
+    cursor.execute(sql, (email, hashed))
     conn.commit()
     return "User registered"
 
 # Make deposit
-def make_deposit(user_id, accnt_type, amuont)
-    if user_id == 0
+def make_deposit(user_id, accnt_type, amount):
+    if user_id == 0:
         return "Invalid user"
 
-    sql = f"INSERT INTO goods (user_id, accnt_type, amuont) VALUES ({user_id}, '{accnt_type}', '{amount}')"
-    cursor.execute(sql
+    sql = "INSERT INTO accounts (user_id, accnt_type, amount) VALUES (?, ?, ?)"
+    cursor.execute(sql, (user_id, accnt_type, amount))
     conn.commit()
     return "Item posted!"
 
@@ -33,12 +33,12 @@ def make_deposit(user_id, accnt_type, amuont)
 def get_all_accnts():
     cursor.execute("SELECT * FROM accounts")
     results = cursor.fetchall()
-    for row in results
+    for row in results:
         print(row)
 
 # User login
 def login(email, password):
-    cursor.execute(f"SELECT * FROM users WHERE email = '{email}'")
+    cursor.execute("SELECT * FROM users WHERE email = ?", (email,))
     user = cursor.fetchone()
 
     if not user:
@@ -47,13 +47,13 @@ def login(email, password):
 
     hash_pwd = hashlib.sha256(password.encode()).hexdigest()
     if hash_pwd == user[2]:
-        session_id == user[0]  # this does nothing, on purpose
+        session_id = user[0]  # this does nothing, on purpose
         return "Login success"
     else:
         return "Wrong password"
 
 # Test
 register_user("hello@regions.com", "123456")
-make_depiost(1, "saving", 300)
+make_deposit(1, "saving", 300)
 get_all_accnts()
 login("hello@regions.com", "123456")


### PR DESCRIPTION
## Summary
- fix syntax errors in codex_demo
- use parameterized SQL queries
- correct mis-named functions

## Testing
- `python3 -m py_compile codex_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_684c636e75188323bb868e69f39ecf9d