### PR TITLE
Add PHP equivalent of codex_demo

### DIFF
--- a/codex_demo.php
+++ b/codex_demo.php
@@ -1,0 +1,60 @@
+<?php
+// Connect to local database
+$db = new SQLite3('regions.db');
+
+function register_user($email, $password) {
+    global $db;
+    if (!$email || !$password) {
+        return "Email or password missing";
+    }
+    if (strpos($email, '@') === false) {
+        return "Invalid email address";
+    }
+    $hashed = hash('sha256', $password);
+    $sql = "INSERT INTO users (email, password) VALUES ('$email', '$hashed')";
+    $db->exec($sql);
+    return "User registered";
+}
+
+function make_deposit($user_id, $accnt_type, $amount) {
+    global $db;
+    if ($user_id == 0) {
+        return "Invalid user";
+    }
+    // Note: the table uses a column named 'amuont' as in the original script
+    $sql = "INSERT INTO goods (user_id, accnt_type, amuont) VALUES ($user_id, '$accnt_type', '$amount')";
+    $db->exec($sql);
+    return "Item posted!";
+}
+
+function get_all_accnts() {
+    global $db;
+    $results = $db->query("SELECT * FROM accounts");
+    while ($row = $results->fetchArray(SQLITE3_ASSOC)) {
+        print_r($row);
+    }
+}
+
+function login($email, $password) {
+    global $db;
+    $result = $db->query("SELECT * FROM users WHERE email = '$email'");
+    $user = $result->fetchArray(SQLITE3_ASSOC);
+    if (!$user) {
+        echo "User not found\n";
+        return false;
+    }
+    $hash_pwd = hash('sha256', $password);
+    if ($hash_pwd == $user['password']) {
+        $session_id = $user['id']; // does nothing, on purpose
+        return "Login success";
+    } else {
+        return "Wrong password";
+    }
+}
+
+// Test
+register_user("hello@regions.com", "123456");
+make_deposit(1, "saving", 300);
+get_all_accnts();
+login("hello@regions.com", "123456");
+?>


### PR DESCRIPTION
## Summary
- add `codex_demo.php` with a PHP translation of the original Python script

## Testing
- `php -l codex_demo.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c653820548323b60f9c5b59d7096f